### PR TITLE
Ignore case enum

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -20,18 +20,18 @@
     <PaketBootstrapperStyle Condition="Exists('$(PaketToolsPath)paket.bootstrapper.proj')">proj</PaketBootstrapperStyle>
     <PaketExeImage>assembly</PaketExeImage>
     <PaketExeImage Condition=" '$(PaketBootstrapperStyle)' == 'proj' ">native</PaketExeImage>
-    <MonoPath Condition="'$(MonoPath)' == '' And Exists('/Library/Frameworks/Mono.framework/Commands/mono')">/Library/Frameworks/Mono.framework/Commands/mono</MonoPath>
+    <MonoPath Condition="'$(MonoPath)' == '' AND Exists('/Library/Frameworks/Mono.framework/Commands/mono')">/Library/Frameworks/Mono.framework/Commands/mono</MonoPath>
     <MonoPath Condition="'$(MonoPath)' == ''">mono</MonoPath>
 
     <!-- PaketBootStrapper  -->
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
-    
-    <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
+
+    <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT' ">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
 
-    <!-- Disable automagic references for F# dotnet sdk -->
+    <!-- Disable automagic references for F# DotNet SDK -->
     <!-- This will not do anything for other project types -->
     <!-- see https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1002-fsharp-in-dotnet-sdk.md -->
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
@@ -40,55 +40,68 @@
     <!-- Disable Paket restore under NCrunch build -->
     <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
 
+    <!-- Disable test for CLI tool completely - overrideable via properties in projects or via environment variables -->
+    <PaketDisableCliTest Condition=" '$(PaketDisableCliTest)' == '' ">False</PaketDisableCliTest>
+
     <PaketIntermediateOutputPath Condition=" '$(PaketIntermediateOutputPath)' == '' ">$(BaseIntermediateOutputPath.TrimEnd('\').TrimEnd('\/'))</PaketIntermediateOutputPath>
   </PropertyGroup>
 
-  <!-- Check if paket is available as local dotnet cli tool -->
+  <!-- Resolve how paket should be called -->
+  <!-- Current priority is: local (1: repo root, 2: .paket folder) => 3: as CLI tool => as bootstrapper (4: proj Bootstrapper style, 5: BootstrapperExeDir) => 6: global path variable -->
   <Target Name="SetPaketCommand" >
-  
-    <!-- Call 'dotnet paket' and see if it returns without an error. Mute all the output. -->
-    <Exec Command="dotnet paket --version" IgnoreExitCode="true" StandardOutputImportance="low" StandardErrorImportance="low" >
+    <!-- Test if paket is available in the standard locations. If so, that takes priority. Case 1/2 - non-windows specific -->
+    <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+      <!-- no windows, try native paket as default, root => tool -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketRootPath)paket') ">$(PaketRootPath)paket</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketToolsPath)paket') ">$(PaketToolsPath)paket</PaketExePath>
+    </PropertyGroup>
+
+    <!-- Test if paket is available in the standard locations. If so, that takes priority. Case 2/2 - same across platforms -->
+    <PropertyGroup>
+      <!-- root => tool -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
+    </PropertyGroup>
+
+    <!-- If paket hasn't be found in standard locations, test for CLI tool usage. -->
+    <!-- First test: Is CLI configured to be used in "dotnet-tools.json"? - can result in a false negative; only a positive outcome is reliable. -->
+    <PropertyGroup Condition=" '$(PaketExePath)' == '' ">
+      <_DotnetToolsJson Condition="Exists('$(PaketRootPath)/.config/dotnet-tools.json')">$([System.IO.File]::ReadAllText("$(PaketRootPath)/.config/dotnet-tools.json"))</_DotnetToolsJson>
+      <_ConfigContainsPaket Condition=" '$(_DotnetToolsJson)' != ''">$(_DotnetToolsJson.Contains('"paket"'))</_ConfigContainsPaket>
+      <_ConfigContainsPaket Condition=" '$(_ConfigContainsPaket)' == ''">false</_ConfigContainsPaket>
+    </PropertyGroup>
+
+    <!-- Second test: Call 'dotnet paket' and see if it returns without an error. Mute all the output. Only run if previous test failed and the test has not been disabled. -->
+    <!-- WARNING: This method can lead to processes hanging forever, and should be used as little as possible. See https://github.com/fsprojects/Paket/issues/3705 for details. -->
+    <Exec Condition=" '$(PaketExePath)' == '' AND !$(PaketDisableCliTest) AND !$(_ConfigContainsPaket)" Command="dotnet paket --version" IgnoreExitCode="true" StandardOutputImportance="low" StandardErrorImportance="low" >
       <Output TaskParameter="ExitCode" PropertyName="LocalPaketToolExitCode" />
     </Exec>
 
-    <!-- If local paket tool is found, use that -->
-    <PropertyGroup Condition=" '$(LocalPaketToolExitCode)' == '0' ">
-      <InternalPaketCommand>dotnet paket</InternalPaketCommand>
+    <!-- If paket is installed as CLI use that. Again, only if paket haven't already been found in standard locations. -->
+    <PropertyGroup Condition=" '$(PaketExePath)' == '' AND ($(_ConfigContainsPaket) OR '$(LocalPaketToolExitCode)' == '0') ">
+      <_PaketCommand>dotnet paket</_PaketCommand>
     </PropertyGroup>
 
-    <!-- If not, then we go through our normal steps of setting the Paket command.  -->
-    <PropertyGroup Condition=" '$(LocalPaketToolExitCode)' != '0' ">
-      <!-- windows, root => tool => proj style => bootstrapper => global -->
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket.exe</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(_PaketBootStrapperExeDir)paket.exe</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' ">paket.exe</PaketExePath>
+    <!-- If neither local files nor CLI tool can be found, final attempt is searching for boostrapper config before falling back to global path variable. -->
+    <PropertyGroup Condition=" '$(PaketExePath)' == '' AND '$(_PaketCommand)' == '' ">
+      <!-- Test for bootstrapper setup -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketBootStrapperExeDir)') ">$(PaketBootStrapperExeDir)paket</PaketExePath>
 
-      <!-- no windows, try native paket as default,  root => tool => proj style => mono paket => bootstrpper => global -->
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket') ">$(PaketRootPath)paket</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket') ">$(PaketToolsPath)paket</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket</PaketExePath>
+      <!-- If all else fails, use global path approach. -->
+      <PaketExePath Condition=" '$(PaketExePath)' == ''">paket</PaketExePath>
+    </PropertyGroup>
 
-      <!-- no windows, try mono paket -->
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
-
-      <!-- no windows, try bootstrapper -->
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(PaketBootStrapperExeDir)paket.exe</PaketExePath>
-
-      <!-- no windows, try global native paket -->
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' ">paket</PaketExePath>
-
+    <!-- If not using CLI, setup correct execution command. -->
+    <PropertyGroup Condition=" '$(_PaketCommand)' == '' ">
       <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
-      <InternalPaketCommand Condition=" '$(InternalPaketCommand)' == '' AND '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</InternalPaketCommand>
-      <InternalPaketCommand Condition=" '$(InternalPaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</InternalPaketCommand>
-      <InternalPaketCommand Condition=" '$(InternalPaketCommand)' == '' ">"$(PaketExePath)"</InternalPaketCommand>
-
+      <_PaketCommand Condition=" '$(_PaketCommand)' == '' AND '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</_PaketCommand>
+      <_PaketCommand Condition=" '$(_PaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</_PaketCommand>
+      <_PaketCommand Condition=" '$(_PaketCommand)' == '' ">"$(PaketExePath)"</_PaketCommand>
     </PropertyGroup>
 
     <!-- The way to get a property to be available outside the target is to use this task. -->
-    <CreateProperty Value="$(InternalPaketCommand)">
+    <CreateProperty Value="$(_PaketCommand)">
       <Output TaskParameter="Value" PropertyName="PaketCommand"/>
     </CreateProperty>
 
@@ -123,7 +136,7 @@
         <!-- Parse our simple 'paket.restore.cached' json ...-->
         <PaketRestoreCachedSplitObject Include="$([System.Text.RegularExpressions.Regex]::Split(`$(PaketRestoreCachedContents)`, `{|}|,`))"></PaketRestoreCachedSplitObject>
         <!-- Keep Key, Value ItemGroup-->
-        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)" 
+        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)"
             Condition=" $([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `&quot;: &quot;`).Length) &gt; 1 ">
           <Key>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[0].Replace(`"`, ``).Replace(` `, ``))</Key>
           <Value>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[1].Replace(`"`, ``).Replace(` `, ``))</Value>
@@ -156,7 +169,7 @@
     <Exec Command='$(PaketBootStrapperCommand)' Condition=" '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
     <Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we need a full restore (hashes don't match)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true'" />
     <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true' " ContinueOnError="false" />
-    
+
     <!-- Step 2 Detect project specific changes -->
     <ItemGroup>
       <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>

--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -20,18 +20,18 @@
     <PaketBootstrapperStyle Condition="Exists('$(PaketToolsPath)paket.bootstrapper.proj')">proj</PaketBootstrapperStyle>
     <PaketExeImage>assembly</PaketExeImage>
     <PaketExeImage Condition=" '$(PaketBootstrapperStyle)' == 'proj' ">native</PaketExeImage>
-    <MonoPath Condition="'$(MonoPath)' == '' AND Exists('/Library/Frameworks/Mono.framework/Commands/mono')">/Library/Frameworks/Mono.framework/Commands/mono</MonoPath>
+    <MonoPath Condition="'$(MonoPath)' == '' And Exists('/Library/Frameworks/Mono.framework/Commands/mono')">/Library/Frameworks/Mono.framework/Commands/mono</MonoPath>
     <MonoPath Condition="'$(MonoPath)' == ''">mono</MonoPath>
 
     <!-- PaketBootStrapper  -->
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
-
-    <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT' ">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
+    
+    <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
 
-    <!-- Disable automagic references for F# DotNet SDK -->
+    <!-- Disable automagic references for F# dotnet sdk -->
     <!-- This will not do anything for other project types -->
     <!-- see https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1002-fsharp-in-dotnet-sdk.md -->
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
@@ -40,68 +40,55 @@
     <!-- Disable Paket restore under NCrunch build -->
     <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
 
-    <!-- Disable test for CLI tool completely - overrideable via properties in projects or via environment variables -->
-    <PaketDisableCliTest Condition=" '$(PaketDisableCliTest)' == '' ">False</PaketDisableCliTest>
-
     <PaketIntermediateOutputPath Condition=" '$(PaketIntermediateOutputPath)' == '' ">$(BaseIntermediateOutputPath.TrimEnd('\').TrimEnd('\/'))</PaketIntermediateOutputPath>
   </PropertyGroup>
 
-  <!-- Resolve how paket should be called -->
-  <!-- Current priority is: local (1: repo root, 2: .paket folder) => 3: as CLI tool => as bootstrapper (4: proj Bootstrapper style, 5: BootstrapperExeDir) => 6: global path variable -->
+  <!-- Check if paket is available as local dotnet cli tool -->
   <Target Name="SetPaketCommand" >
-    <!-- Test if paket is available in the standard locations. If so, that takes priority. Case 1/2 - non-windows specific -->
-    <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-      <!-- no windows, try native paket as default, root => tool -->
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketRootPath)paket') ">$(PaketRootPath)paket</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketToolsPath)paket') ">$(PaketToolsPath)paket</PaketExePath>
-    </PropertyGroup>
-
-    <!-- Test if paket is available in the standard locations. If so, that takes priority. Case 2/2 - same across platforms -->
-    <PropertyGroup>
-      <!-- root => tool -->
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
-    </PropertyGroup>
-
-    <!-- If paket hasn't be found in standard locations, test for CLI tool usage. -->
-    <!-- First test: Is CLI configured to be used in "dotnet-tools.json"? - can result in a false negative; only a positive outcome is reliable. -->
-    <PropertyGroup Condition=" '$(PaketExePath)' == '' ">
-      <_DotnetToolsJson Condition="Exists('$(PaketRootPath)/.config/dotnet-tools.json')">$([System.IO.File]::ReadAllText("$(PaketRootPath)/.config/dotnet-tools.json"))</_DotnetToolsJson>
-      <_ConfigContainsPaket Condition=" '$(_DotnetToolsJson)' != ''">$(_DotnetToolsJson.Contains('"paket"'))</_ConfigContainsPaket>
-      <_ConfigContainsPaket Condition=" '$(_ConfigContainsPaket)' == ''">false</_ConfigContainsPaket>
-    </PropertyGroup>
-
-    <!-- Second test: Call 'dotnet paket' and see if it returns without an error. Mute all the output. Only run if previous test failed and the test has not been disabled. -->
-    <!-- WARNING: This method can lead to processes hanging forever, and should be used as little as possible. See https://github.com/fsprojects/Paket/issues/3705 for details. -->
-    <Exec Condition=" '$(PaketExePath)' == '' AND !$(PaketDisableCliTest) AND !$(_ConfigContainsPaket)" Command="dotnet paket --version" IgnoreExitCode="true" StandardOutputImportance="low" StandardErrorImportance="low" >
+  
+    <!-- Call 'dotnet paket' and see if it returns without an error. Mute all the output. -->
+    <Exec Command="dotnet paket --version" IgnoreExitCode="true" StandardOutputImportance="low" StandardErrorImportance="low" >
       <Output TaskParameter="ExitCode" PropertyName="LocalPaketToolExitCode" />
     </Exec>
 
-    <!-- If paket is installed as CLI use that. Again, only if paket haven't already been found in standard locations. -->
-    <PropertyGroup Condition=" '$(PaketExePath)' == '' AND ($(_ConfigContainsPaket) OR '$(LocalPaketToolExitCode)' == '0') ">
-      <_PaketCommand>dotnet paket</_PaketCommand>
+    <!-- If local paket tool is found, use that -->
+    <PropertyGroup Condition=" '$(LocalPaketToolExitCode)' == '0' ">
+      <InternalPaketCommand>dotnet paket</InternalPaketCommand>
     </PropertyGroup>
 
-    <!-- If neither local files nor CLI tool can be found, final attempt is searching for boostrapper config before falling back to global path variable. -->
-    <PropertyGroup Condition=" '$(PaketExePath)' == '' AND '$(_PaketCommand)' == '' ">
-      <!-- Test for bootstrapper setup -->
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketBootStrapperExeDir)') ">$(PaketBootStrapperExeDir)paket</PaketExePath>
+    <!-- If not, then we go through our normal steps of setting the Paket command.  -->
+    <PropertyGroup Condition=" '$(LocalPaketToolExitCode)' != '0' ">
+      <!-- windows, root => tool => proj style => bootstrapper => global -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket.exe</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(_PaketBootStrapperExeDir)paket.exe</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' ">paket.exe</PaketExePath>
 
-      <!-- If all else fails, use global path approach. -->
-      <PaketExePath Condition=" '$(PaketExePath)' == ''">paket</PaketExePath>
-    </PropertyGroup>
+      <!-- no windows, try native paket as default,  root => tool => proj style => mono paket => bootstrpper => global -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket') ">$(PaketRootPath)paket</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket') ">$(PaketToolsPath)paket</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket</PaketExePath>
 
-    <!-- If not using CLI, setup correct execution command. -->
-    <PropertyGroup Condition=" '$(_PaketCommand)' == '' ">
+      <!-- no windows, try mono paket -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
+
+      <!-- no windows, try bootstrapper -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(PaketBootStrapperExeDir)paket.exe</PaketExePath>
+
+      <!-- no windows, try global native paket -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' ">paket</PaketExePath>
+
       <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
-      <_PaketCommand Condition=" '$(_PaketCommand)' == '' AND '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</_PaketCommand>
-      <_PaketCommand Condition=" '$(_PaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</_PaketCommand>
-      <_PaketCommand Condition=" '$(_PaketCommand)' == '' ">"$(PaketExePath)"</_PaketCommand>
+      <InternalPaketCommand Condition=" '$(InternalPaketCommand)' == '' AND '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</InternalPaketCommand>
+      <InternalPaketCommand Condition=" '$(InternalPaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</InternalPaketCommand>
+      <InternalPaketCommand Condition=" '$(InternalPaketCommand)' == '' ">"$(PaketExePath)"</InternalPaketCommand>
+
     </PropertyGroup>
 
     <!-- The way to get a property to be available outside the target is to use this task. -->
-    <CreateProperty Value="$(_PaketCommand)">
+    <CreateProperty Value="$(InternalPaketCommand)">
       <Output TaskParameter="Value" PropertyName="PaketCommand"/>
     </CreateProperty>
 
@@ -136,7 +123,7 @@
         <!-- Parse our simple 'paket.restore.cached' json ...-->
         <PaketRestoreCachedSplitObject Include="$([System.Text.RegularExpressions.Regex]::Split(`$(PaketRestoreCachedContents)`, `{|}|,`))"></PaketRestoreCachedSplitObject>
         <!-- Keep Key, Value ItemGroup-->
-        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)"
+        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)" 
             Condition=" $([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `&quot;: &quot;`).Length) &gt; 1 ">
           <Key>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[0].Replace(`"`, ``).Replace(` `, ``))</Key>
           <Value>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[1].Replace(`"`, ``).Replace(` `, ``))</Value>
@@ -169,7 +156,7 @@
     <Exec Command='$(PaketBootStrapperCommand)' Condition=" '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
     <Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we need a full restore (hashes don't match)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true'" />
     <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true' " ContinueOnError="false" />
-
+    
     <!-- Step 2 Detect project specific changes -->
     <ItemGroup>
       <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>

--- a/docsrc/content/index.fsx
+++ b/docsrc/content/index.fsx
@@ -148,7 +148,8 @@ type Config = {
 Discriminated Union Type
 -----------------
 
-FsConfig supports Discriminated Union Types that has cases alone. 
+FsConfig supports Discriminated Union Types that has cases alone.
+
 
 *)
 
@@ -165,7 +166,62 @@ type Config = {
 
 > With this configuration declaration, FsConfig read the environment variable `CONSOLE_COLOR` and populates the `ConsoleColor` field of type `Color`.
 
-> List of Discriminated Union Types also supported!
+> List of Discriminated Union Types also supported: see under _List Type_
+
+Enumerations
+-----------------
+
+FsConfig can read enumerations using either their numeric values or their case names.
+
+The `[<Flags>]` attribute is also supported, using only comma-separated values.
+
+*)
+
+[<Flags>]
+type Status =
+| Inactive = 0
+| Receiving = 1
+| Transmitting = 2
+
+type Config = {
+  Status : Status
+}
+
+(**
+
+> This will result in the status `Receiving ||| Transmitting` 
+```bash
+STATUS=Receiving,Transmitting
+```
+
+> This will result in the status `Inactive` 
+```bash
+STATUS=0
+```
+
+Case sensitivity
+-----------------
+
+When parsing enumerations or discriminated unions, FsConfig will first look for an exact match (case sensitive), but if no matches are found, it will also accept a case-insensitive match.
+
+*)
+
+type LogLevel =
+| Debug = 0
+| Informative = 1
+| Warning = 2
+| Error = 3
+
+type Config = {
+  LogLevel : LogLevel
+}
+
+(**
+
+> This is a valid configuration
+```bash
+LOG_LEVEL=warning
+```
 
 List Type
 ---------
@@ -256,6 +312,7 @@ type Config = {
   [<DefaultValue("Server=localhost;Port=5432;Database=FsTweet;User Id=postgres;Password=test;")>]
   DbConnectionString: string
 }
+
 
 (**
 

--- a/src/FsConfig/Config.fs
+++ b/src/FsConfig/Config.fs
@@ -112,7 +112,10 @@ module internal Core =
                                     and 'Enum : struct
                                     and 'Enum :> ValueType
                                     and 'Enum : (new : unit -> 'Enum)> () =
-          tryParse System.Enum.TryParse<'Enum> value |> wrap
+          
+          // cannot use tryParse as the function has a different signature with the ignoreCase option added                                    
+          let success, result = System.Enum.TryParse<'Enum>(value = value, ignoreCase = true)
+          wrap (if success then Some result else None)
     }
 
   let getTryParseFunc<'T> targetTypeShape =

--- a/src/FsConfig/Config.fs
+++ b/src/FsConfig/Config.fs
@@ -100,12 +100,14 @@ module internal Core =
   let tryParseFSharpDU (shape : ShapeFSharpUnion<'T>) value =
     shape.UnionCases 
     |> Seq.tryFind (fun c -> c.CaseInfo.Name = value)
+    |> Option.orElseWith (fun () -> shape.UnionCases |> Seq.tryFind (fun c -> String.Equals(c.CaseInfo.Name, value, StringComparison.InvariantCultureIgnoreCase)))
     |> Option.map (fun c -> c.CreateUninitialized ())
 
 
   let tryParseEnum<'T> (enumShape : IShapeEnum) value = 
     let wrap (p : Option<'a>) =
       unbox<Option<'T>> p
+
     enumShape.Accept {
       new IEnumVisitor<'T option> with
         member __.Visit<'Enum, 'U when 'Enum : enum<'U>
@@ -114,8 +116,15 @@ module internal Core =
                                     and 'Enum : (new : unit -> 'Enum)> () =
           
           // cannot use tryParse as the function has a different signature with the ignoreCase option added                                    
-          let success, result = System.Enum.TryParse<'Enum>(value = value, ignoreCase = true)
-          wrap (if success then Some result else None)
+          let success, result = System.Enum.TryParse<'Enum>(value = value, ignoreCase = false)
+
+          if success then Some result else 
+              
+              let caseInsensitiveSuccess, caseInsensitiveResult = System.Enum.TryParse<'Enum>(value = value, ignoreCase = true)
+
+              if caseInsensitiveSuccess then Some caseInsensitiveResult else None
+
+          |> wrap
     }
 
   let getTryParseFunc<'T> targetTypeShape =

--- a/tests/FsConfig.Tests/Common.fs
+++ b/tests/FsConfig.Tests/Common.fs
@@ -63,14 +63,31 @@ module Common =
   | Blue = 1
   | Green = 2
   
+  
+  [<Flags>]
+  type CaseSensitiveColor =
+  | Purple = 0
+  | purple = 1
+  | PURPLE = 2
+  | pURPLE = 3
+
   type DuColor =
   | Red
   | Blue
   | Green
 
+  type CaseSensitiveDuColor =
+  | Purple
+  | PURPLE
+
   type DuConfig = {
     DuColor : DuColor
   }
+
+  type CaseSensitiveDuConfig = {
+    CaseSensitiveDuColor : CaseSensitiveDuColor
+  }
+
   type DuListConfig = {
     DuColors : DuColor list
   }

--- a/tests/FsConfig.Tests/EnvConfig.fs
+++ b/tests/FsConfig.Tests/EnvConfig.fs
@@ -193,6 +193,31 @@ module ``Given required environment variables exists`` =
     test <@ EnvConfig.Get<Color> "ENV_ENUM_STRING" = Ok Color.Red @>
     test <@ EnvConfig.Get<Color> "ENV_ENUM_INT" = Ok Color.Red @>
     test <@ EnvConfig.Get<Color> "ENV_ENUM_FLAGS" = Ok expectedFlagOutput @>
+
+    
+  [<Test>]
+  let ``get Enum should still be case-sensitive if it matters`` () =
+    setEnvVar ("ENV_ENUM_STRING", "PURPLE")
+    test <@ EnvConfig.Get<CaseSensitiveColor> "ENV_ENUM_STRING" = Ok CaseSensitiveColor.PURPLE @>
+    setEnvVar ("ENV_ENUM_STRING", "purple")
+    test <@ EnvConfig.Get<CaseSensitiveColor> "ENV_ENUM_STRING" = Ok CaseSensitiveColor.purple @>
+    setEnvVar ("ENV_ENUM_STRING", "PURPLE")
+    test <@ EnvConfig.Get<CaseSensitiveColor> "ENV_ENUM_STRING" = Ok CaseSensitiveColor.PURPLE @>
+    setEnvVar ("ENV_ENUM_STRING", "pURPLE")
+    test <@ EnvConfig.Get<CaseSensitiveColor> "ENV_ENUM_STRING" = Ok CaseSensitiveColor.pURPLE @>
+    
+    setEnvVar ("ENV_ENUM_INT", "0")
+    test <@ EnvConfig.Get<CaseSensitiveColor> "ENV_ENUM_INT" = Ok CaseSensitiveColor.Purple @>
+    setEnvVar ("ENV_ENUM_INT", "1")
+    test <@ EnvConfig.Get<CaseSensitiveColor> "ENV_ENUM_INT" = Ok CaseSensitiveColor.purple @>
+
+    setEnvVar ("ENV_ENUM_FLAGS", "Purple, pURPLE")
+    let expectedFlagOutput1 = CaseSensitiveColor.Purple ||| CaseSensitiveColor.pURPLE
+    test <@ EnvConfig.Get<CaseSensitiveColor> "ENV_ENUM_FLAGS" = Ok expectedFlagOutput1 @>
+    setEnvVar ("ENV_ENUM_FLAGS", "Purple, purple")
+    let expectedFlagOutput2 = CaseSensitiveColor.Purple ||| CaseSensitiveColor.purple
+    test <@ EnvConfig.Get<CaseSensitiveColor> "ENV_ENUM_FLAGS" = Ok expectedFlagOutput2 @>
+    
     
   type Colors = {
     Colors : Color list
@@ -217,6 +242,19 @@ module ``Given required environment variables exists`` =
   let ``get DU list should succeed`` () =
     setEnvVar ("DU_COLORS", "Red, Blue")
     test <@ EnvConfig.Get<DuListConfig> () = Ok {DuColors = [DuColor.Red; DuColor.Blue];} @>
+        
+  [<Test>]
+  let ``get DU should succeed case-insensitively`` () =
+    setEnvVar ("DU_COLOR", "red")
+    test <@ EnvConfig.Get<DuConfig> () = Ok {DuColor = DuColor.Red} @>
+        
+  [<Test>]
+  let ``get DU should succeed case-sensitively when it matters`` () =
+    setEnvVar ("CASE_SENSITIVE_DU_COLOR", "Purple")
+    test <@ EnvConfig.Get<CaseSensitiveDuConfig> () = Ok {CaseSensitiveDuColor = CaseSensitiveDuColor.Purple } @>
+    setEnvVar ("CASE_SENSITIVE_DU_COLOR", "PURPLE")
+    test <@ EnvConfig.Get<CaseSensitiveDuConfig> () = Ok {CaseSensitiveDuColor = CaseSensitiveDuColor.PURPLE} @>
+
   [<Test>]
   let ``get DU list should fail for invalid value`` () =
     setEnvVar ("DU_COLORS", "Red, Blue, NotAvailable")

--- a/tests/FsConfig.Tests/EnvConfig.fs
+++ b/tests/FsConfig.Tests/EnvConfig.fs
@@ -184,6 +184,16 @@ module ``Given required environment variables exists`` =
     test <@ EnvConfig.Get<Color> "ENV_ENUM_INT" = Ok Color.Red @>
     test <@ EnvConfig.Get<Color> "ENV_ENUM_FLAGS" = Ok expectedFlagOutput @>
 
+  [<Test>]
+  let ``get Enum should succeed case-insensitively`` () =
+    setEnvVar ("ENV_ENUM_STRING", "RED")
+    setEnvVar ("ENV_ENUM_FLAGS", "rEd, BlUe")
+    setEnvVar ("ENV_ENUM_INT", "0")
+    let expectedFlagOutput = Color.Red ||| Color.Blue
+    test <@ EnvConfig.Get<Color> "ENV_ENUM_STRING" = Ok Color.Red @>
+    test <@ EnvConfig.Get<Color> "ENV_ENUM_INT" = Ok Color.Red @>
+    test <@ EnvConfig.Get<Color> "ENV_ENUM_FLAGS" = Ok expectedFlagOutput @>
+    
   type Colors = {
     Colors : Color list
   }
@@ -193,6 +203,11 @@ module ``Given required environment variables exists`` =
     setEnvVar ("COLORS", "Red, Green, Blue")
     test <@ EnvConfig.Get<Colors> () = Ok {Colors = [Color.Red;Color.Green;Color.Blue]} @>
 
+  [<Test>]
+  let ``get Enum list should succeed case-insensitively`` () =
+    setEnvVar ("COLORS", "Red, GREEN, blue")
+    test <@ EnvConfig.Get<Colors> () = Ok {Colors = [Color.Red;Color.Green;Color.Blue]} @>
+    
   [<Test>]
   let ``get DU should succeed`` () =
     setEnvVar ("DU_COLOR", "Red")


### PR DESCRIPTION
It's idiomatic to give PascalCase names to .NET enums, but environment variables are more commonly written in ALLCAPS. I have forgotten multiple times to write values in PascalCase, resulting in a crash at startup.

This PR enables the `ignoreCase` flag in the `TryParse` invocation for enum values.

It could be a breaking change *if* somebody had multiple enum cases distinguished only by case, which is technically possible. I'm not aware of any legitimate reasons to do so.