### PR TITLE
Revert "Add support for URIs."

### DIFF
--- a/src/FsConfig/Config.fs
+++ b/src/FsConfig/Config.fs
@@ -154,11 +154,6 @@ module internal Core =
       wrap (tryParseEnum<'T> enumShape)
     | Shape.FSharpUnion (:? ShapeFSharpUnion<'T> as shape) ->
       wrap (tryParseFSharpDU shape)
-    | Shape.Uri ->
-      wrap (fun s ->
-          try
-              Some (Uri s)
-          with _ -> None)
     | _ -> None
 
   let parseFSharpOption<'T> name value (fsharpOption : IShapeFSharpOption) =

--- a/tests/FsConfig.Tests/AppConfig.fs
+++ b/tests/FsConfig.Tests/AppConfig.fs
@@ -1,6 +1,5 @@
 namespace AppConfig.Tests
 
-open System
 open NUnit.Framework
 open FsConfig
 open Swensen.Unquote.Assertions
@@ -26,16 +25,8 @@ module ``App Config tests`` =
     [<Test>] 
     member __.``getPrimitive should succeeds`` () =
       test <@ appConfig.Get<int> "processId" = Ok 123   @>
-
-    [<Test>]
-    member __.``getUri should succeed`` () =
-      test <@ appConfig.Get<ConfigWithUri> () = Ok { Uri = Uri("https://example.com") } @>
-
-    [<Test>]
-    member __.``getUri should return error with invalid URIs`` () =
-      test <@ appConfig.Get<ConfigWithInvalidUri> () = Error(BadValue("InvalidUri", "invalid")) @>
-
-    [<Test>]
+    
+    [<Test>] 
     member __.``getRecord should succeeds`` () =
       test <@ appConfig.Get<SampleConfig> () = Ok {ProcessId = 123; ProcessName = "FsConfig"}   @>
 
@@ -73,13 +64,6 @@ module ``App Config tests`` =
     member __.``getPrimitive should succeeds`` () =
       test <@ appConfig.Get<int> "processId" = Ok 123   @>
 
-    [<Test>]
-    member __.``getUri should succeed`` () =
-      test <@ appConfig.Get<ConfigWithUri> () = Ok { Uri = Uri("https://example.com") } @>
-
-    [<Test>]
-    member __.``getUri should return error with invalid URIs`` () =
-      test <@ appConfig.Get<ConfigWithInvalidUri> () = Error(BadValue("InvalidUri", "invalid")) @>
 
     [<Test>] 
     member __.``getRecord should succeeds`` () =
@@ -120,14 +104,7 @@ module ``App Config tests`` =
     [<Test>] 
     member __.``getRecord should succeeds`` () =
       test <@ appConfig.Get<SampleConfig> () = Ok {ProcessId = 123; ProcessName = "FsConfig"}   @>
-
-    [<Test>]
-    member __.``getUri should succeed`` () =
-      test <@ appConfig.Get<ConfigWithUri> () = Ok { Uri = Uri("https://example.com") } @>
-
-    [<Test>]
-    member __.``getUri should return error with invalid URIs`` () =
-      test <@ appConfig.Get<ConfigWithInvalidUri> () = Error(BadValue("InvalidUri", "invalid")) @>
+    
 
     [<Test>]
     member __.``get list of DU with custom name`` () =

--- a/tests/FsConfig.Tests/settings.ini
+++ b/tests/FsConfig.Tests/settings.ini
@@ -2,8 +2,6 @@ ProcessId=123
 ProcessName=FsConfig
 MagicNumber=42
 Colors=Red,Green
-Uri=https://example.com
-InvalidUri=invalid
 
 [Aws]
 AccessKeyId=Id-123

--- a/tests/FsConfig.Tests/settings.json
+++ b/tests/FsConfig.Tests/settings.json
@@ -7,7 +7,5 @@
     "defaultRegion" : "us-east-1",
     "secretAccessKey" : "secret123"
   },
-  "colors" : "Red,Green",
-  "uri": "https://example.com",
-  "invalidUri": "invalid"
+  "colors" : "Red,Green"
 }

--- a/tests/FsConfig.Tests/settings.xml
+++ b/tests/FsConfig.Tests/settings.xml
@@ -8,6 +8,4 @@
     <SecretAccessKey>secret123</SecretAccessKey>
   </Aws>
   <Colors>Red,Green</Colors>
-  <Uri>https://example.com</Uri>
-  <InvalidUri>invalid</InvalidUri>
 </Settings>


### PR DESCRIPTION
Reverts demystifyfp/FsConfig#24

Those changes break the build. I need to double-check why there is no build runs on PRs (which would've caught it).